### PR TITLE
link github repoURL

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -18,7 +18,7 @@ const users = [
 		infoLink: 'https://www.facebook.com',
 		pinned: true,
 	},
-]
+];
 
 const siteConfig = {
 	title: 'baby-degu', // Title for your website.
@@ -107,7 +107,7 @@ const siteConfig = {
 
 	// You may provide arbitrary config keys to be used as needed by your
 	// template. For example, if you need your repo's URL...
-	//   repoUrl: 'https://github.com/facebook/test-site',
-}
+	repoUrl: 'https://github.com/baby-degu/docusaurus',
+};
 
-module.exports = siteConfig
+module.exports = siteConfig;

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -100,10 +100,10 @@ const siteConfig = {
 	// docsSideNavCollapsible: true,
 
 	// Show documentation's last contributor's name.
-	// enableUpdateBy: true,
+	enableUpdateBy: true,
 
 	// Show documentation's last update time.
-	// enableUpdateTime: true,
+	enableUpdateTime: true,
 
 	// You may provide arbitrary config keys to be used as needed by your
 	// template. For example, if you need your repo's URL...


### PR DESCRIPTION
## Related Issue
- #13 

## Details of Changes
- enable to link to github repository url.
- fix prettier setting

<img width="313" alt="スクリーンショット 2020-05-11 0 15 42" src="https://user-images.githubusercontent.com/36391432/81503144-f7900680-931c-11ea-867f-811298b1ddeb.png">
